### PR TITLE
use nil as key and thus randomly dispatcher to partitions

### DIFF
--- a/datagen/sink/kafka/kafka.go
+++ b/datagen/sink/kafka/kafka.go
@@ -113,7 +113,7 @@ func (p *KafkaSink) WriteRecord(ctx context.Context, record sink.SinkRecord) err
 	topic, data := record.ToKafka()
 	msg := &sarama.ProducerMessage{}
 	msg.Topic = topic
-	msg.Key = sarama.StringEncoder(topic)
+	msg.Key = nil
 	msg.Value = sarama.ByteEncoder(data)
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
Sarama will use the hash value of the key of the message as the choice of partition.

When it is `nil`, it will be randomly chosed.