### PR TITLE
fix: redpanda metrics in promethus

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - compactor-node
       - "--listen-addr"
       - "0.0.0.0:6660"
+      - "--advertise-addr"
+      - "compactor-0:6660"
       - "--prometheus-listener-addr"
       - "0.0.0.0:1260"
       - "--metrics-level"
@@ -41,10 +43,10 @@ services:
       - compute-node
       - "--listen-addr"
       - "0.0.0.0:5688"
-      - "--prometheus-listener-addr"
-      - "0.0.0.0:1222"
       - "--advertise-addr"
       - "compute-node-0:5688"
+      - "--prometheus-listener-addr"
+      - "0.0.0.0:1222"
       - "--metrics-level"
       - "1"
       - "--state-store"
@@ -60,8 +62,6 @@ services:
     depends_on:
       - meta-node-0
       - minio-0
-    volumes:
-      - "./risingwave.toml:/risingwave.toml"
     environment:
       RUST_BACKTRACE: "1"
     container_name: compute-node-0
@@ -127,6 +127,12 @@ services:
       - "0.0.0.0:4566"
       - "--meta-addr"
       - "http://meta-node-0:5690"
+      - "--advertise-addr"
+      - "frontend-node-0:4566"
+      - "--prometheus-listener-addr"
+      - "0.0.0.0:2222"
+      - "--metrics-level"
+      - "1"
     expose:
       - "4566"
     ports:

--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -38,4 +38,4 @@ scrape_configs:
 
   - job_name: redpanda
     static_configs:
-      - targets: ["redpanda:9644"]
+      - targets: ["message_queue:9644"]


### PR DESCRIPTION
fix https://github.com/risingwavelabs/risingwave/issues/8342

Also add back some lost config in #94

Now the log collection of all components works well:

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/10192522/223683844-9e037a70-d678-4736-a5f9-b690e05f567c.png">
